### PR TITLE
Remove protectable from contributions edit+write

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -247,8 +247,8 @@
             "validationErrorContent": "Bitte gib Deinem Beitrag einen Text",
             "validationErrorCategories": "Wähle wenigstens eine Kategorie aus, um den Beitrag abspeichern zu können",
             "creatorFemaleOrMale": "Autorin ::: Autor",
-            "draft": "Entwurf",
-            "draftMsg": "Bist Du sicher, dass Du Deinen Entwurf verwerfen möchtest?"
+            "draft": "Ungespeicherte Änderungen",
+            "draftMsg": "Bist Du sicher, dass Du Deinen Kommentar verwerfen möchtest?"
         },
         "organization": {
             "createNew": "Neue Organisation erstellen",

--- a/locales/en.json
+++ b/locales/en.json
@@ -247,8 +247,8 @@
             "validationErrorContent": "Please provide a text",
             "validationErrorCategories": "Choose at least one category to be able to save this contribution",
             "creatorFemaleOrMale": "Author ::: Author",
-            "draft": "Draft",
-            "draftMsg": "Are you sure you want to discard your current draft?"
+            "draft": "Unsaved changes",
+            "draftMsg": "Are you sure that you want to discard your current comment?"
         },
         "organization": {
             "createNew": "Create new Organization",

--- a/pages/contributions/edit/_slug.vue
+++ b/pages/contributions/edit/_slug.vue
@@ -4,7 +4,7 @@
       <div class="card">
         <section class="section">
           <!--<h1 class="title">Edit {{ title }}</h1>-->
-          <contributions-form v-on:input="editorText" :data="form"></contributions-form>
+          <contributions-form :data="form"></contributions-form>
         </section>
       </div>
     </div>
@@ -13,10 +13,8 @@
 
 <script>
   import ContributionsForm from '~/components/Contributions/ContributionsForm.vue'
-  import protectable from '~/components/mixins/protectable'
 
   export default {
-    mixins: [protectable],
     middleware: ['verified', 'owner'],
     components: {
       ContributionsForm
@@ -47,11 +45,6 @@
     head () {
       return {
         title: `Edit ${this.title}`
-      }
-    },
-    methods: {
-      editorText (newText) {
-        this.protectText(newText)
       }
     }
   }

--- a/pages/contributions/write.vue
+++ b/pages/contributions/write.vue
@@ -3,7 +3,7 @@
     <div class="column is-8 is-offset-2">
       <div class="card" :class="classes">
         <section class="section">
-          <contributions-form v-on:input="editorText" @validate="onValidate" />
+          <contributions-form @validate="onValidate" />
         </section>
       </div>
     </div>
@@ -13,11 +13,10 @@
 <script>
   import animatable from '~/components/mixins/animatable'
   import ContributionsForm from '~/components/Contributions/ContributionsForm.vue'
-  import protectable from '~/components/mixins/protectable'
 
   export default {
     middleware: ['authenticated', 'verified'],
-    mixins: [animatable, protectable],
+    mixins: [animatable],
     components: {
       ContributionsForm
     },
@@ -25,9 +24,6 @@
       this.$destroy()
     },
     methods: {
-      editorText (newText) {
-        this.protectText(newText)
-      },
       onValidate (success) {
         if (!success) {
           this.animate('shake')


### PR DESCRIPTION
The confirmation dialog is opened on our staging environment when you try to
create a contribution. A successful update or create will redirect you to the
contribution show page, thus trigger beforeRouteLeave and opening the
confirmation dialog. The greatest value of the confirmation dialog is currently
on the comments, so I will remove it from the contribution for now.


@ionphractal FYI