### PR TITLE
Contribution draft confirmation

### DIFF
--- a/components/Contributions/ContributionsForm.vue
+++ b/components/Contributions/ContributionsForm.vue
@@ -452,6 +452,7 @@
         } catch (err) {
           console.error(err)
           this.isLoading = false
+          this.$emit('validate', false)
           this.$toast.open({
             message: err.message,
             type: 'is-danger'

--- a/components/mixins/protectable.js
+++ b/components/mixins/protectable.js
@@ -1,7 +1,7 @@
 // This mixin can be loaded for every page component with input fields. It will confirm leaving the page in case the user has some (unsaved) input/draft pending.
 let protectable = {
   beforeRouteLeave (to, from, next) {
-    if (this.isComposing) {
+    if (this.isComposing && !this.isSubmitting) {
       this.$dialog.confirm({
         title: this.$t('component.contribution.draft'),
         message: this.$t('component.contribution.draftMsg'),
@@ -17,6 +17,8 @@ let protectable = {
   },
   mounted () {
     window.addEventListener('beforeunload', this.beforeUnload)
+    this.isSubmitting = false
+    this.isComposing = false
   },
   beforeDestroy () {
     window.removeEventListener('beforeunload', this.beforeUnload)

--- a/components/mixins/protectable.js
+++ b/components/mixins/protectable.js
@@ -1,6 +1,7 @@
 // This mixin can be loaded for every page component with input fields. It will confirm leaving the page in case the user has some (unsaved) input/draft pending.
 let protectable = {
   beforeRouteLeave (to, from, next) {
+    next(false)
     if (this.isComposing && !this.isSubmitting) {
       this.$dialog.confirm({
         title: this.$t('component.contribution.draft'),

--- a/pages/contributions/edit/_slug.vue
+++ b/pages/contributions/edit/_slug.vue
@@ -1,10 +1,9 @@
 <template>
   <div class="columns">
-    <div class=" column is-8 is-offset-2">
-      <div class="card">
+    <div class="column is-8 is-offset-2">
+      <div class="card" :class="classes">
         <section class="section">
-          <!--<h1 class="title">Edit {{ title }}</h1>-->
-          <contributions-form :data="form"></contributions-form>
+          <contributions-form :data="form" v-on:input="editorText" @validate="onValidate" />
         </section>
       </div>
     </div>
@@ -13,11 +12,27 @@
 
 <script>
   import ContributionsForm from '~/components/Contributions/ContributionsForm.vue'
+  import animatable from '~/components/mixins/animatable'
+  import protectable from '~/components/mixins/protectable'
 
   export default {
     middleware: ['verified', 'owner'],
+    mixins: [animatable, protectable],
     components: {
       ContributionsForm
+    },
+    methods: {
+      editorText (newText) {
+        this.protectText(newText)
+      },
+      onValidate (success) {
+        if (!success) {
+          this.animate('shake')
+          this.isSubmitting = false
+        } else {
+          this.isSubmitting = true
+        }
+      }
     },
     async asyncData ({app, params, error}) {
       try {

--- a/pages/contributions/write.vue
+++ b/pages/contributions/write.vue
@@ -3,7 +3,7 @@
     <div class="column is-8 is-offset-2">
       <div class="card" :class="classes">
         <section class="section">
-          <contributions-form @validate="onValidate" />
+          <contributions-form v-on:input="editorText" @validate="onValidate" />
         </section>
       </div>
     </div>
@@ -11,12 +11,13 @@
 </template>
 
 <script>
-  import animatable from '~/components/mixins/animatable'
   import ContributionsForm from '~/components/Contributions/ContributionsForm.vue'
+  import animatable from '~/components/mixins/animatable'
+  import protectable from '~/components/mixins/protectable'
 
   export default {
     middleware: ['authenticated', 'verified'],
-    mixins: [animatable],
+    mixins: [animatable, protectable],
     components: {
       ContributionsForm
     },
@@ -24,9 +25,15 @@
       this.$destroy()
     },
     methods: {
+      editorText (newText) {
+        this.protectText(newText)
+      },
       onValidate (success) {
         if (!success) {
           this.animate('shake')
+          this.isSubmitting = false
+        } else {
+          this.isSubmitting = true
         }
       }
     }


### PR DESCRIPTION
After the form elements are validated, the 'validate' is emitted to signal validation is complete and the submission process begins. I found this suitable to also set the submit flag, so I extended the function. The state is reset in case of an error along with the same animation which seems appropriate to me. This is also applied to the edit page.

@appinteractive @roschaefer @mimicc83 Please review.

fixes #300 
closes #301 