### PR TITLE
Remove some remains of arguments for sentry

### DIFF
--- a/plugins/raven-client.js
+++ b/plugins/raven-client.js
@@ -9,7 +9,6 @@ export default ({app}) => {
         release: app.$env.BUILD_COMMIT,
         environment: app.$env.NODE_ENV,
         tags: {
-          deployed: app.$env.BUILD_DATE,
           client: true
         }
       })

--- a/plugins/raven-server.js
+++ b/plugins/raven-server.js
@@ -10,7 +10,6 @@ export default async function (app) {
       release: process.env.BUILD_COMMIT,
       environment: process.env.NODE_ENV,
       tags: {
-        deployed: process.env.DEPLOY_DATE,
         client: true
       }
     }).install()


### PR DESCRIPTION
These are obsolete because we're sending the BUILD_COMMIT to sentry.