### PR TITLE
Fix 321

### DIFF
--- a/store/comments.js
+++ b/store/comments.js
@@ -76,28 +76,24 @@ export const actions = {
     }
     commit('setContributionId', contributionId)
 
-    return new Promise((resolve, reject) => {
-      this.app.$api.service('comments').find({
-        query: {
-          contributionId: contributionId,
-          $sort: {
-            // upvoteCount: -1,
-            createdAt: 1
-          },
-          $skip: state.comments.length,
-          $limit: 30
-        }
-      }).then((result) => {
-        // as we load new comments, make sure they are in the right order and unique
-        let newComments = orderBy(uniqWith(state.comments.concat(result.data), (a, b) => a._id === b._id), ['createdAt'], ['asc'])
-        commit('set', newComments)
-        commit('setCommentCount', result.total)
-        commit('isLoading', false)
-        resolve()
-      }).catch((e) => {
-        commit('isLoading', false)
-        reject(new Error(e))
-      })
+    return this.app.$api.service('comments').find({
+      query: {
+        contributionId: contributionId,
+        $sort: {
+          // upvoteCount: -1,
+          createdAt: 1
+        },
+        $skip: state.comments.length,
+        $limit: 30
+      }
+    }).then((result) => {
+      // as we load new comments, make sure they are in the right order and unique
+      let newComments = orderBy(uniqWith(state.comments.concat(result.data), (a, b) => a._id === b._id), ['createdAt'], ['asc'])
+      commit('setCommentCount', result.total)
+      commit('set', newComments)
+      commit('isLoading', false)
+    }).catch((e) => {
+      commit('isLoading', false)
     })
   },
   fetchById ({commit}, id) {

--- a/store/comments.test.js
+++ b/store/comments.test.js
@@ -61,8 +61,8 @@ describe('given a mock api', () => {
         await action({state, dispatch, commit}, 42)
         const expected = [
           [ 'setContributionId', 42 ],
-          [ 'set', [] ],
           [ 'setCommentCount', 0 ],
+          [ 'set', [] ],
           [ 'isLoading', false ]
         ]
         expect(commit.mock.calls).toEqual(expected)
@@ -73,8 +73,8 @@ describe('given a mock api', () => {
         await action({state, dispatch, commit}, 42)
         const expected = [
           [ 'setContributionId', 42 ],
-          [ 'set', [{_id: 23}] ],
           [ 'setCommentCount', 1 ],
+          [ 'set', [{_id: 23}] ],
           [ 'isLoading', false ]
         ]
         expect(commit.mock.calls).toEqual(expected)


### PR DESCRIPTION
@ionphractal I'm sure, this *really* fixes #321

Run `git checkout 9502320fa4598a6893ad335fd11ca74191eb6b3e -- store` to see the regression test in action. The problem was **not** that feathers `$api` does not return a promise. It does. The actual problem is that `fetchAllByContributionId` does not return a promise and therefore you cannot wait for it.