### PR TITLE
Fix typo, brake to break

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -14,7 +14,7 @@
             "copy403": "Sorry, access to this resource on the server is denied. <br />Either check the URL, <a href=\"/auth/login\">login</a> or <a href=\"/\">go home</a>.",
             "copy404": "Sorry, the page you're looking for cannot be found. <br />Either check the URL, <a href=\"/\">go home</a>, or feel free to <a href=\"mailto:support@human-connection.org\">report this issue.</a>",
             "copy500": "An error ocurred and your request couldn’t be completed. <br />Either check the URL, <a href=\"/\">go home</a>, or feel free to <a href=\"mailto:support@human-connection.org\">report this issue.</a>",
-            "copy503": "We are currently working on it, <br />so take a coffee brake and come back a bit later."
+            "copy503": "We are currently working on it, <br />so take a coffee break and come back a bit later."
         },
         "badges": {
             "user_role_moderator": "Moderator",


### PR DESCRIPTION
I noticed this typo, spelling break as in `take a break` like brake as in `a device for slowing or stopping a moving vehicle, typically by applying pressure to the wheels.`